### PR TITLE
minor changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -30,6 +30,10 @@ jobs:
       - name: Install Dependencies
         run: |
           npm install --ignore-scripts
+
+      - name: Lint
+        run: |
+          npm run lint
 
       - name: Run Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          npm run test:ci
+          npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "index.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "tap test.js",
-    "test:typescript": "tsd",
-    "test:ci": "npm run test && npm run test:typescript"
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:unit": "tap test.js",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "fastify-plugin": "^3.0.1"
   },
   "devDependencies": {
+    "@types/node": "^18.7.13",
     "fastify": "^4.2.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "plugin.js",
   "types": "index.d.ts",
   "scripts": {
+    "lint": "standard | standard",
     "test": "tap test.js",
     "test:typescript": "tsd",
     "test:ci": "npm run test && npm run test:typescript"
@@ -27,11 +28,9 @@
   },
   "devDependencies": {
     "fastify": "^4.2.0",
-    "got": "^11.8.5",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
-    "tsd": "^0.21.0",
-    "typescript": "~4.7.4"
+    "tsd": "^0.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "types": "index.d.ts",
   "scripts": {
-    "lint": "standard | standard",
+    "lint": "standard | snazzy",
     "test": "tap test.js",
     "test:typescript": "tsd",
     "test:ci": "npm run test && npm run test:typescript"

--- a/test.js
+++ b/test.js
@@ -1,27 +1,16 @@
 'use strict'
 
 const test = require('tap').test
-const got = require('got')
 
-test('it returns an empty 404', (t) => {
-  t.plan(3)
+test('it returns an empty 404', async (t) => {
+  t.plan(2)
   const fastify = require('fastify')()
-  fastify.register(require('./'))
+  fastify.register(require('.'))
 
-  fastify.listen({
-    port: 0,
-  }, (err) => {
-    fastify.server.unref()
-    if (err) t.threw(err)
-    const port = fastify.server.address().port
-    got(`http://127.0.0.1:${port}/favicon.ico`)
-      .then(() => {
-        t.fail('should receive an error')
-      })
-      .catch(err => {
-        t.type(err, Error)
-        t.equal(err.response.statusCode, 404)
-        t.equal(+err.response.headers['content-length'], 0)
-      })
-  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response = await fastify.inject('/favicon.ico')
+  t.equal(response.statusCode, 404)
+  t.equal(response.headers['content-length'], '0')
 })


### PR DESCRIPTION
disable package-lock generation
remove got as devDependency and use instead fastify.inject
test again node 18
remove typescript as devDependency
lint in ci